### PR TITLE
Fix the invalid main field

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "is-gen-fn",
   "version": "0.0.1",
   "description": "determine if a function is a generator function",
-  "main": "yes",
+  "main": "index.js",
   "scripts": {
     "test": "make test"
   },


### PR DESCRIPTION
@matthewmueller

`koa-joi-router` module depends on `is-gen-fn` directly or indirectly and we're seeing the following in the console due to the invalid main field value:

> (node:28) [DEP0128] DeprecationWarning: Invalid 'main' field in '/home/node/app/node_modules/is-gen-fn/package.json' of 'yes'. Please either fix that or report it to the module author

Do you mind merging and pushing a patch release to `npm` to clear out the error?