### PR TITLE
fix 'main' declaration in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "is-gen-fn",
   "version": "0.0.1",
   "description": "determine if a function is a generator function",
-  "main": "yes",
+  "main": "index.js",
   "scripts": {
     "test": "make test"
   },


### PR DESCRIPTION
this PR fixes a package.json issue that ends up creating a lot of log noise as multiple projects (like create-react-app) use this lib and the `main` field in package.json being set to `yes` triggers a deprecation warning.